### PR TITLE
De 1548 detected out of order data for prospects

### DIFF
--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -134,10 +134,7 @@ class Client:
 
         self.access_token = data.get("access_token")
         if not self.access_token:
-            LOGGER.warning(
-                "failed to refresh token: %s",
-                response.json()
-            )
+            LOGGER.warning("failed to refresh token: %s", response.json())
             raise PardotException(response)
 
     def describe(self, endpoint, **kwargs):

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -169,7 +169,7 @@ class CreatedAtReplicationStream(Stream):
     replication_method = "INCREMENTAL"
 
     def get_default_start(self):
-        return (datetime.now() - timedelta(days=10*365)).strftime('%Y-%m-%d %H:%M:%S')
+        return (datetime.now() - timedelta(days=10 * 365)).strftime("%Y-%m-%d %H:%M:%S")
 
     def get_params(self):
         return {
@@ -455,7 +455,7 @@ class VisitorActivities(CreatedAtReplicationStream):
     data_key = "visitor_activity"
     endpoint = "visitorActivity"
     # We've encountered a situation where we have been unable to finish the sync due
-    # to fetching too much data. Data Sciense is only using some types of visitor 
+    # to fetching too much data. Data Sciense is only using some types of visitor
     # activities. Hence, we can filter out the used ones only.
     filter_types = "1,2,4,6,17,21,24,25,26,27,28,29,34"
     datetime_format = "%Y-%m-%d %H:%M:%S"
@@ -465,14 +465,15 @@ class VisitorActivities(CreatedAtReplicationStream):
 
         # In order to avoid timeouts, we need to drasticaly limit the amount of activities that we
         # ask Pardot to process per request.
-        cb = datetime.strptime(p["created_after"], self.datetime_format) + timedelta(days=7)
-
-        p.update(
-            type=self.filter_types,
-            created_before=cb.strftime(self.datetime_format)
+        cb = datetime.strptime(p["created_after"], self.datetime_format) + timedelta(
+            days=7
         )
 
-        return p 
+        p.update(
+            type=self.filter_types, created_before=cb.strftime(self.datetime_format)
+        )
+
+        return p
 
     def sync(self):
         self.pre_sync()
@@ -491,7 +492,9 @@ class VisitorActivities(CreatedAtReplicationStream):
                     n += 1
                     yield rec
 
-                if n == 0 and now < datetime.strptime(self.get_params()["created_before"], self.datetime_format):
+                if n == 0 and now < datetime.strptime(
+                    self.get_params()["created_before"], self.datetime_format
+                ):
                     break
         except InvalidCredentials as e:
             LOGGER.error(

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -223,6 +223,13 @@ class UpdatedAtReplicationStream(Stream):
 
             params["offset"] += 200
 
+            # Since the updated_after query filter is exclusive, we need to consider the case where
+            # the last record of page N has the same updated_at value as the first record of page N+1.
+            # Since Pardot's smallest unit of time is seconds, we simply deduct one second, guaranteeing
+            # that, should page N+1 fail, then we will never lose any records.
+            bookmark = datetime.strptime(bookmark, "%Y-%m-%d %H:%M:%S") - timedelta(seconds=1)
+            bookmark = bookmark.strftime("%Y-%m-%d %H:%M:%S")
+
             self.update_bookmark(bookmark)
 
 


### PR DESCRIPTION
I have deliberately not added a `updated_before` filter. This has the advantage that we only need to paginate through the data that actually exists, but also has the disadvantage that each api call will be considerably slower for large ranges.

I've chosen to keep the pagination logic only for "updated at" streams, just so this doesn't break anything by mistake.